### PR TITLE
fix: Enable changing name of MSK configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,6 +156,10 @@ resource "aws_msk_configuration" "this" {
   description       = var.configuration_description
   kafka_versions    = [var.kafka_version]
   server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add lifecycle create before destroy rule for msk configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To enable changing name of MSK configuration
[AWS Terraform provider related issue](https://github.com/hashicorp/terraform-provider-aws/issues/15831)

## Breaking Changes
<!-- Does this break backwards-compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
