### PR TITLE
feat: Add support for multi-vpc private connectivity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.83.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ No modules.
 | [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_configuration) | resource |
 | [aws_msk_scram_secret_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_scram_secret_association) | resource |
+| [aws_msk_vpc_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_vpc_connection) | resource |
 | [aws_mskconnect_custom_plugin.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_custom_plugin) | resource |
 | [aws_mskconnect_worker_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_worker_configuration) | resource |
 
@@ -209,6 +210,7 @@ No modules.
 | <a name="input_storage_mode"></a> [storage\_mode](#input\_storage\_mode) | Controls storage mode for supported storage tiers. Valid values are: `LOCAL` or `TIERED` | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources created | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
+| <a name="input_vpc_connections"></a> [vpc\_connections](#input\_vpc\_connections) | Map of VPC Connection details | `map(any)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
 
 ## Modules
 
@@ -210,7 +210,7 @@ No modules.
 | <a name="input_storage_mode"></a> [storage\_mode](#input\_storage\_mode) | Controls storage mode for supported storage tiers. Valid values are: `LOCAL` or `TIERED` | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources created | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
-| <a name="input_vpc_connections"></a> [vpc\_connections](#input\_vpc\_connections) | Map of VPC Connection details | `map(any)` | `{}` | no |
+| <a name="input_vpc_connections"></a> [vpc\_connections](#input\_vpc\_connections) | Map of VPC Connections to create | `any` | `{}` | no |
 
 ## Outputs
 
@@ -235,6 +235,7 @@ No modules.
 | <a name="output_schema_registries"></a> [schema\_registries](#output\_schema\_registries) | A map of output attributes for the schema registries created |
 | <a name="output_schemas"></a> [schemas](#output\_schemas) | A map of output attributes for the schemas created |
 | <a name="output_scram_secret_association_id"></a> [scram\_secret\_association\_id](#output\_scram\_secret\_association\_id) | Amazon Resource Name (ARN) of the MSK cluster |
+| <a name="output_vpc_connections"></a> [vpc\_connections](#output\_vpc\_connections) | A map of output attributes for the VPC connections created |
 | <a name="output_zookeeper_connect_string"></a> [zookeeper\_connect\_string](#output\_zookeeper\_connect\_string) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphabetically |
 | <a name="output_zookeeper_connect_string_tls"></a> [zookeeper\_connect\_string\_tls](#output\_zookeeper\_connect\_string\_tls) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphabetically |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,13 +23,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
 
 ## Modules
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.12"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,6 +40,8 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_s3_logs_bucket"></a> [s3\_logs\_bucket](#module\_s3\_logs\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc_connection"></a> [vpc\_connection](#module\_vpc\_connection) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc_connection_security_group"></a> [vpc\_connection\_security\_group](#module\_vpc\_connection\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
 
 ## Resources
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -33,21 +33,25 @@ module "msk_cluster" {
   number_of_broker_nodes = 3
   enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
 
-  broker_node_client_subnets  = module.vpc.private_subnets
+  broker_node_client_subnets = module.vpc.private_subnets
+  broker_node_connectivity_info = {
+    public_access = {
+      type = "DISABLED"
+    }
+    vpc_connectivity = {
+      client_authentication = {
+        tls = false
+        sasl = {
+          iam   = false
+          scram = true
+        }
+      }
+    }
+  }
   broker_node_instance_type   = "kafka.m5.large"
   broker_node_security_groups = [module.security_group.security_group_id]
   broker_node_storage_info = {
     ebs_storage_info = { volume_size = 100 }
-  }
-  broker_node_connectivity_info = {
-    public_access = "DISABLED"
-    vpc_connectivity = {
-      tls = false
-      sasl = {
-        iam   = false
-        scram = true
-      }
-    }
   }
 
   vpc_connections = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,8 +8,9 @@ locals {
   name   = "ex-${basename(path.cwd)}"
   region = "us-east-1"
 
-  vpc_cidr = "10.0.0.0/16"
-  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+  vpc_cidr            = "10.0.0.0/16"
+  vpc_connection_cidr = "10.1.0.0/16"
+  azs                 = slice(data.aws_availability_zones.available.names, 0, 3)
 
   secrets = ["producer", "consumer"]
 
@@ -33,10 +34,29 @@ module "msk_cluster" {
   enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
 
   broker_node_client_subnets  = module.vpc.private_subnets
-  broker_node_instance_type   = "kafka.t3.small"
+  broker_node_instance_type   = "kafka.m5.large"
   broker_node_security_groups = [module.security_group.security_group_id]
   broker_node_storage_info = {
     ebs_storage_info = { volume_size = 100 }
+  }
+  broker_node_connectivity_info = {
+    public_access = "DISABLED"
+    vpc_connectivity = {
+      tls = false
+      sasl = {
+        iam   = false
+        scram = true
+      }
+    }
+  }
+
+  vpc_connections = {
+    connection_one = {
+      authentication  = "SASL_SCRAM"
+      vpc_id          = module.vpc_connection.vpc_id
+      client_subnets  = module.vpc_connection.private_subnets
+      security_groups = [module.vpc_connection_security_group.security_group_id]
+    }
   }
 
   encryption_in_transit_client_broker = "TLS"
@@ -230,6 +250,46 @@ module "s3_logs_bucket" {
       }
     }
   }
+
+  tags = local.tags
+}
+
+################################################################################
+# VPC Connections
+################################################################################
+
+module "vpc_connection_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.name}-vpc-connection"
+  description = "Security group for ${local.name} VPC Connection"
+  vpc_id      = module.vpc_connection.vpc_id
+
+  ingress_cidr_blocks = module.vpc_connection.private_subnets_cidr_blocks
+  ingress_rules = [
+    "kafka-broker-tcp",
+    "kafka-broker-tls-tcp"
+  ]
+
+  tags = local.tags
+}
+
+module "vpc_connection" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${local.name}-vpc-connection"
+  cidr = local.vpc_connection_cidr
+
+  azs              = local.azs
+  public_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_connection_cidr, 8, k)]
+  private_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_connection_cidr, 8, k + 3)]
+  database_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_connection_cidr, 8, k + 6)]
+
+  create_database_subnet_group = true
+  enable_nat_gateway           = true
+  single_nat_gateway           = true
 
   tags = local.tags
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/connect/README.md
+++ b/examples/connect/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules

--- a/examples/connect/versions.tf
+++ b/examples/connect/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.12"
     }
     null = {
       source  = "hashicorp/null"

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,15 @@ output "zookeeper_connect_string_tls" {
 }
 
 ################################################################################
+# VPC Connection
+################################################################################
+
+output "vpc_connections" {
+  description = "A map of output attributes for the VPC connections created"
+  value       = aws_msk_vpc_connection.this
+}
+
+################################################################################
 # Configuration
 ################################################################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -331,3 +331,13 @@ variable "connect_worker_config_properties_file_content" {
   type        = string
   default     = null
 }
+
+################################################################################
+# VPC Connections
+################################################################################
+
+variable "vpc_connections" {
+  description = "Map of VPC Connection details"
+  type        = map(any)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,16 @@ variable "timeouts" {
 }
 
 ################################################################################
+# VPC Connection
+################################################################################
+
+variable "vpc_connections" {
+  description = "Map of VPC Connections to create"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # Configuration
 ################################################################################
 
@@ -330,14 +340,4 @@ variable "connect_worker_config_properties_file_content" {
   description = "Contents of connect-distributed.properties file. The value can be either base64 encoded or in raw format"
   type        = string
   default     = null
-}
-
-################################################################################
-# VPC Connections
-################################################################################
-
-variable "vpc_connections" {
-  description = "Map of VPC Connection details"
-  type        = map(any)
-  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.12.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12.0"
+      version = ">= 5.12"
     }
   }
 }


### PR DESCRIPTION
## Description
This change adds support for adding "Multi-VPC" connections to a cluster.

https://docs.aws.amazon.com/msk/latest/developerguide/aws-access-mult-vpc.html

## Motivation and Context
This adds support for enabling multi-vpc connections for a cluster, and creating aws_msk_vpc_connection to a VPC which was released in [version 5.12.0 of the aws provider](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5120-august-10-2023).

## Breaking Changes
I don't believe there are any breaking changes introduced by this change, however enabling multi-vpc requires that the cluster be already running instances larger than `kafka.t3.small`. I was unable to enable multi-vpc and scale up the instance size in the same operation.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

This was tested by modifying the `examples/complete` module. The cluster was first upgraded to `kafka.m5.large` in one operation, then multi-vpc was enabled in another operation.