### PR TITLE
feat: Allow MSK configuration changes on running clusters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.2
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 
 ## Modules
 
@@ -157,7 +157,7 @@ No modules.
 | [aws_msk_vpc_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_vpc_connection) | resource |
 | [aws_mskconnect_custom_plugin.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_custom_plugin) | resource |
 | [aws_mskconnect_worker_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_worker_configuration) | resource |
-| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/id) | resource |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -129,12 +129,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 
@@ -155,6 +157,7 @@ No modules.
 | [aws_msk_vpc_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_vpc_connection) | resource |
 | [aws_mskconnect_custom_plugin.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_custom_plugin) | resource |
 | [aws_mskconnect_worker_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mskconnect_worker_configuration) | resource |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/id) | resource |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -189,13 +189,15 @@ resource "aws_msk_vpc_connection" "this" {
 ################################################################################
 
 resource "random_id" "this" {
+  count = var.create && var.create_configuration ? 1 : 0
+
   byte_length = 8
 }
 
 resource "aws_msk_configuration" "this" {
   count = var.create && var.create_configuration ? 1 : 0
 
-  name              = format("%s-%s", coalesce(var.configuration_name, var.name), random_id.this.dec)
+  name              = format("%s-%s", coalesce(var.configuration_name, var.name), random_id.this[0].dec)
   description       = var.configuration_description
   kafka_versions    = [var.kafka_version]
   server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])

--- a/main.tf
+++ b/main.tf
@@ -188,13 +188,21 @@ resource "aws_msk_vpc_connection" "this" {
 # Configuration
 ################################################################################
 
+resource "random_id" "this" {
+  byte_length = 8
+}
+
 resource "aws_msk_configuration" "this" {
   count = var.create && var.create_configuration ? 1 : 0
 
-  name              = coalesce(var.configuration_name, var.name)
+  name              = format("%s-%s", coalesce(var.configuration_name, var.name), random_id.this.dec)
   description       = var.configuration_description
   kafka_versions    = [var.kafka_version]
   server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.12"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.0"
+      version = ">= 3.6"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For the latest version of this module [v2.3.0](https://github.com/terraform-aws-modules/terraform-aws-msk-kafka-cluster/releases/tag/v2.3.0), an operator cannot change the MSK configuration for a cluster which has already been created with this module. As pointed out by @ascpikmin in issue #16, the `aws_msk_configuration` resource requires a `lifecycle` block with `create_before_destroy = true` set. This in turn requires the `name` attribute of the `aws_msk_configuration` resource to be unique.

<!--- If it fixes an open issue, please link to the issue here. -->

This pull-request aims to resolve issue #16.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->

This change preserves backwards compatibility with the current major version.

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?

This has been tested by executing a `terraform apply` using the following module declaration:

```terraform
module "complete_mks_cluster_test" {
  source = "github.com/GreggSchofield/terraform-aws-msk-kafka-cluster" # Head of fork

  name                   = format("%s-test-cluster", terraform.workspace)
  kafka_version          = "3.6.0"
  number_of_broker_nodes = 3

  broker_node_client_subnets  = data.aws_subnets.subnets.ids
  broker_node_instance_type   = "kafka.m7g.large"
  broker_node_security_groups = [module.complete_security_group.security_group_id]

  broker_node_storage_info = {
    ebs_storage_info = {
      volume_size = 100
    }
  }
  scaling_max_capacity = 200
  scaling_target_value = 80

  encryption_at_rest_kms_key_arn = try(data.aws_kms_key.id_env_kms_key.arn, null)

  encryption_in_transit_client_broker = "TLS"
  encryption_in_transit_in_cluster    = true

  configuration_name              = format("%s-test-configuration", terraform.workspace)
  configuration_server_properties = {}
```

then setting the `configuration_server_properties` attribute to `{"auto.create.topics.enable" = true}` to force a new MSK Cluster configuration version to be created :

```terraform
module "complete_mks_cluster_test" {
  source = "github.com/GreggSchofield/terraform-aws-msk-kafka-cluster" # Head of fork

  name                   = format("%s-test-cluster", terraform.workspace)
  kafka_version          = "3.6.0"
  number_of_broker_nodes = 3

  broker_node_client_subnets  = data.aws_subnets.subnets.ids
  broker_node_instance_type   = "kafka.m7g.large"
  broker_node_security_groups = [module.complete_security_group.security_group_id]

  broker_node_storage_info = {
    ebs_storage_info = {
      volume_size = 100
    }
  }
  scaling_max_capacity = 200
  scaling_target_value = 80

  encryption_at_rest_kms_key_arn = try(data.aws_kms_key.id_env_kms_key.arn, null)

  encryption_in_transit_client_broker = "TLS"
  encryption_in_transit_in_cluster    = true

  configuration_name              = format("%s-test-configuration", terraform.workspace)
  configuration_server_properties = {"auto.create.topics.enable" = true}
```

Given the current composition of this module, in particular the fact that the `aws_msk_configuration` resource is created within the module scope, executing `terraform plan` will yield a single in-place update:

```terraform
Terraform will perform the following actions:

  # module.complete_mks_cluster_test.aws_msk_configuration.this[0] will be updated in-place
  ~ resource "aws_msk_configuration" "this" {
        id                = "arn:aws:kafka:eu-west-1:account-id:configuration/data-streaming-eu-west-1-stable-int-test-configuration-4909326019387697745/cluster-id"
      ~ latest_revision   = 1 -> (known after apply)
        name              = "data-streaming-eu-west-1-stable-int-test-configuration-4909326019387697745"
      + server_properties = "auto.create.topics.enable = true"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Only once this has been applied, can the operator then execute `terraform plan` again to yield the desired in-place update for the cluster itself:


```terraform
Terraform will perform the following actions:

  # module.complete_mks_cluster_test.aws_msk_cluster.this[0] will be updated in-place
  ~ resource "aws_msk_cluster" "this" {
        id                           = "arn:aws:kafka:eu-west-1:account-id:cluster/data-streaming-eu-west-1-stable-int-test-cluster/cluster-id"
        tags                         = {}
        # (12 unchanged attributes hidden)

      ~ configuration_info {
          ~ revision = 1 -> 2
            # (1 unchanged attribute hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

https://github.com/terraform-aws-modules/terraform-aws-msk-kafka-cluster/assets/28576265/1c35263e-ea3e-4081-b5cc-36efa80fb5e2