### PR TITLE
docs: Update Kafka versions in examples to match AWS recommended version

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -26,7 +26,7 @@ module "msk_cluster" {
   source = "../.."
 
   name                   = local.name
-  kafka_version          = "3.4.0"
+  kafka_version          = "3.5.1"
   number_of_broker_nodes = 3
 
   broker_node_client_subnets  = module.vpc.private_subnets

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,7 +29,7 @@ module "msk_cluster" {
   source = "../.."
 
   name                   = local.name
-  kafka_version          = "3.4.0"
+  kafka_version          = "3.5.1"
   number_of_broker_nodes = 3
   enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
 

--- a/examples/connect/main.tf
+++ b/examples/connect/main.tf
@@ -29,7 +29,7 @@ module "msk_cluster" {
   source = "../.."
 
   name                   = local.name
-  kafka_version          = "3.4.0"
+  kafka_version          = "3.5.1"
   number_of_broker_nodes = 3
 
   broker_node_client_subnets  = module.vpc.private_subnets


### PR DESCRIPTION
## Description
I updated the Kafka version.

## Motivation and Context
In the AWS console its recommended to use version 3.5.1.

## Breaking Changes
- 

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
