### PR TITLE
feat: Create a new configuration when the Kafka version is changed to avoid `ConflictException: A resource with this name already exists` errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -250,6 +250,10 @@ data "aws_iam_policy_document" "this" {
 resource "random_id" "this" {
   count = var.create && var.create_configuration ? 1 : 0
 
+  keepers = {
+    kafka_version = var.kafka_version
+  }
+
   byte_length = 8
 }
 
@@ -258,7 +262,7 @@ resource "aws_msk_configuration" "this" {
 
   name              = format("%s-%s", coalesce(var.configuration_name, var.name), random_id.this[0].dec)
   description       = var.configuration_description
-  kafka_versions    = [var.kafka_version]
+  kafka_versions    = [random_id.this[0].keepers.kafka_version]
   server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])
 
   lifecycle {


### PR DESCRIPTION
## Description
I've tried to upgrade MSK cluster that was created by this module and got an error resource with this name already exists. After checking source files, I found that random_id is not recreated on every update of the configuration or changing version of the MSK cluster. 

You can read about this here: https://registry.terraform.io/providers/hashicorp/random/latest/docs

>As noted above, the random resources generate randomness only when they are created; the results produced are stored in the Terraform state and re-used until the inputs change, prompting the resource to be recreated.
> 
> The resources all provide a map argument called keepers that can be populated with arbitrary key/value pairs that should be selected such that they remain the same until new random values are desired.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seamless experience using this module while upgrading MSK cluster version or changing configuration parameters.

> Error: creating MSK Configuration: operation error Kafka: CreateConfiguration, https response error StatusCode: 409, ConflictException: A resource with this name already exists.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have tested it on my dev environment
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

pre-commit run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
