### PR TITLE
feat: Add tags to AppAutoscaling target

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,6 +313,8 @@ resource "aws_appautoscaling_target" "this" {
   resource_id        = aws_msk_cluster.this[0].arn
   scalable_dimension = "kafka:broker-storage:VolumeSize"
   service_namespace  = "kafka"
+
+  tags = var.tags
 }
 
 resource "aws_appautoscaling_policy" "this" {


### PR DESCRIPTION
## Description
added `tags` attribute to `aws_appautoscaling_target` resource for consistent tagging across resources

## Motivation and Context
this change adds tags to the autoscaling target, aligning with standardized tagging practices. enhances visibility and management of resources within AWS

## Breaking Changes
no breaking changes; this addition is backward-compatible with the existing configuration

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects