### PR TITLE
feat: Add cluster name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ No modules.
 | <a name="output_bootstrap_brokers_sasl_iam"></a> [bootstrap\_brokers\_sasl\_iam](#output\_bootstrap\_brokers\_sasl\_iam) | One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true` |
 | <a name="output_bootstrap_brokers_sasl_scram"></a> [bootstrap\_brokers\_sasl\_scram](#output\_bootstrap\_brokers\_sasl\_scram) | One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true` |
 | <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the MSK cluster |
 | <a name="output_cluster_uuid"></a> [cluster\_uuid](#output\_cluster\_uuid) | UUID of the MSK cluster, for use in IAM policies |
 | <a name="output_configuration_arn"></a> [configuration\_arn](#output\_configuration\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_configuration_latest_revision"></a> [configuration\_latest\_revision](#output\_configuration\_latest\_revision) | Latest revision of the configuration |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -63,6 +63,7 @@ No inputs.
 | <a name="output_bootstrap_brokers_sasl_iam"></a> [bootstrap\_brokers\_sasl\_iam](#output\_bootstrap\_brokers\_sasl\_iam) | One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true` |
 | <a name="output_bootstrap_brokers_sasl_scram"></a> [bootstrap\_brokers\_sasl\_scram](#output\_bootstrap\_brokers\_sasl\_scram) | One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true` |
 | <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the MSK cluster |
 | <a name="output_cluster_uuid"></a> [cluster\_uuid](#output\_cluster\_uuid) | UUID of the MSK cluster, for use in IAM policies |
 | <a name="output_configuration_arn"></a> [configuration\_arn](#output\_configuration\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_configuration_latest_revision"></a> [configuration\_latest\_revision](#output\_configuration\_latest\_revision) | Latest revision of the configuration |

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -32,6 +32,11 @@ output "bootstrap_brokers_tls" {
   value       = module.msk_cluster.bootstrap_brokers_tls
 }
 
+output "cluster_name" {
+  description = "Name of the MSK cluster"
+  value       = module.msk_cluster.cluster_name
+}
+
 output "cluster_uuid" {
   description = "UUID of the MSK cluster, for use in IAM policies"
   value       = module.msk_cluster.cluster_uuid

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -72,6 +72,7 @@ No inputs.
 | <a name="output_bootstrap_brokers_sasl_iam"></a> [bootstrap\_brokers\_sasl\_iam](#output\_bootstrap\_brokers\_sasl\_iam) | One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true` |
 | <a name="output_bootstrap_brokers_sasl_scram"></a> [bootstrap\_brokers\_sasl\_scram](#output\_bootstrap\_brokers\_sasl\_scram) | One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true` |
 | <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the MSK cluster |
 | <a name="output_cluster_uuid"></a> [cluster\_uuid](#output\_cluster\_uuid) | UUID of the MSK cluster, for use in IAM policies |
 | <a name="output_configuration_arn"></a> [configuration\_arn](#output\_configuration\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_configuration_latest_revision"></a> [configuration\_latest\_revision](#output\_configuration\_latest\_revision) | Latest revision of the configuration |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -32,6 +32,11 @@ output "bootstrap_brokers_tls" {
   value       = module.msk_cluster.bootstrap_brokers_tls
 }
 
+output "cluster_name" {
+  description = "Name of the MSK cluster"
+  value       = module.msk_cluster.cluster_name
+}
+
 output "cluster_uuid" {
   description = "UUID of the MSK cluster, for use in IAM policies"
   value       = module.msk_cluster.cluster_uuid

--- a/examples/connect/README.md
+++ b/examples/connect/README.md
@@ -66,6 +66,7 @@ No inputs.
 | <a name="output_bootstrap_brokers_sasl_iam"></a> [bootstrap\_brokers\_sasl\_iam](#output\_bootstrap\_brokers\_sasl\_iam) | One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true` |
 | <a name="output_bootstrap_brokers_sasl_scram"></a> [bootstrap\_brokers\_sasl\_scram](#output\_bootstrap\_brokers\_sasl\_scram) | One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true` |
 | <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the MSK cluster |
 | <a name="output_cluster_uuid"></a> [cluster\_uuid](#output\_cluster\_uuid) | UUID of the MSK cluster, for use in IAM policies |
 | <a name="output_configuration_arn"></a> [configuration\_arn](#output\_configuration\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_configuration_latest_revision"></a> [configuration\_latest\_revision](#output\_configuration\_latest\_revision) | Latest revision of the configuration |

--- a/examples/connect/outputs.tf
+++ b/examples/connect/outputs.tf
@@ -32,6 +32,11 @@ output "bootstrap_brokers_tls" {
   value       = module.msk_cluster.bootstrap_brokers_tls
 }
 
+output "cluster_name" {
+  description = "Name of the MSK cluster"
+  value       = module.msk_cluster.cluster_name
+}
+
 output "cluster_uuid" {
   description = "UUID of the MSK cluster, for use in IAM policies"
   value       = module.msk_cluster.cluster_uuid

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,11 @@ output "bootstrap_brokers_tls" {
   value       = try(aws_msk_cluster.this[0].bootstrap_brokers_tls, null)
 }
 
+output "cluster_name" {
+  description = "Name of the MSK cluster"
+  value       = var.name
+}
+
 output "cluster_uuid" {
   description = "UUID of the MSK cluster, for use in IAM policies"
   value       = try(aws_msk_cluster.this[0].cluster_uuid, null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,7 +39,7 @@ output "bootstrap_brokers_tls" {
 
 output "cluster_name" {
   description = "Name of the MSK cluster"
-  value       = var.name
+  value       = try(aws_msk_cluster.this[0].cluster_name, null)
 }
 
 output "cluster_uuid" {


### PR DESCRIPTION
## Description
Sometimes it's useful to have this value as output, for instance, when using terragrunt and use this module as dependency of another module.

## Motivation and Context
Just adds the output with cluster name. Useful when using module as dependency of another module.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have tested and validated these changes using production cluster :)