### PR TITLE
fix: The logging info block should not be present if node types are "express*"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_msk_cluster" "this" {
   kafka_version       = var.kafka_version
 
   dynamic "logging_info" {
-    for_each = startswith(var.broker_node_instance_type, "express") ? [] : ["BROKER_LOGS"]
+    for_each = startswith(var.broker_node_instance_type, "express") ? [] : [true]
     content {
       broker_logs {
         cloudwatch_logs {

--- a/main.tf
+++ b/main.tf
@@ -117,22 +117,25 @@ resource "aws_msk_cluster" "this" {
   enhanced_monitoring = var.enhanced_monitoring
   kafka_version       = var.kafka_version
 
-  logging_info {
-    broker_logs {
-      cloudwatch_logs {
-        enabled   = var.cloudwatch_logs_enabled
-        log_group = var.cloudwatch_logs_enabled ? local.cloudwatch_log_group : null
-      }
+  dynamic "logging_info" {
+    for_each = startswith(var.broker_node_instance_type, "express") ? [] : ["BROKER_LOGS"]
+    content {
+      broker_logs {
+        cloudwatch_logs {
+          enabled   = var.cloudwatch_logs_enabled
+          log_group = var.cloudwatch_logs_enabled ? local.cloudwatch_log_group : null
+        }
 
-      firehose {
-        enabled         = var.firehose_logs_enabled
-        delivery_stream = var.firehose_delivery_stream
-      }
+        firehose {
+          enabled         = var.firehose_logs_enabled
+          delivery_stream = var.firehose_delivery_stream
+        }
 
-      s3 {
-        bucket  = var.s3_logs_bucket
-        enabled = var.s3_logs_enabled
-        prefix  = var.s3_logs_prefix
+        s3 {
+          bucket  = var.s3_logs_bucket
+          enabled = var.s3_logs_enabled
+          prefix  = var.s3_logs_prefix
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_msk_cluster" "this" {
   kafka_version       = var.kafka_version
 
   dynamic "logging_info" {
-    for_each = startswith(var.broker_node_instance_type, "express") ? [] : [true]
+    for_each = length(regexall("^express", var.broker_node_instance_type)) > 0 ? [] : [true]
     content {
       broker_logs {
         cloudwatch_logs {


### PR DESCRIPTION
## Description
This addresses #47 by making the logging config block dynamic

Fixes #47

## Motivation and Context
Fixes a bug that prevents configuring the cluster with express brokers.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
I tested on my private (corperate) project to make it work for express brokers, i have not tested for standard brokers.
